### PR TITLE
fix: change regex so it correctly identifies html encoded tags

### DIFF
--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/mathExpressionFormatter.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/mathExpressionFormatter.kt
@@ -32,7 +32,7 @@ fun mathExpressionFormatter(
                 "</sup>" -> pop()
                 "<sub>" -> pushStyle(SpanStyle(baselineShift = BaselineShift.Subscript, fontSize = 0.7.em))
                 "</sub>" -> pop()
-                "&nbsp;" -> pop()
+                "&nbsp;" -> append("")
                 else -> append(token.value)
             }
         }

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/mathExpressionFormatter.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/mathExpressionFormatter.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.em
 fun mathExpressionFormatter(
     text: String
 ): AnnotatedString {
-    val tokens = Regex("""<.*?>|(&nbsp;)+|([^<&]+)?""").findAll(text)
+    val tokens = Regex("""<.*?>|(&[a-z]+;)+|([^<&]+)?""").findAll(text)
 
     // TODO: Implement <small> tags. (Apparently only used for base designation? https://github.com/Qalculate/libqalculate/blob/21f28b27bf99dc6d9f3325c4960a92ec9ee8934d/libqalculate/MathStructure-print.cc#L3604 )
 
@@ -33,6 +33,9 @@ fun mathExpressionFormatter(
                 "<sub>" -> pushStyle(SpanStyle(baselineShift = BaselineShift.Subscript, fontSize = 0.7.em))
                 "</sub>" -> pop()
                 "&nbsp;" -> append("")
+                "&lt;" -> append("<")
+                "&gt;" -> append(">")
+                "&amp;" -> append("&")
                 else -> append(token.value)
             }
         }

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/mathExpressionFormatter.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/mathExpressionFormatter.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.em
 fun mathExpressionFormatter(
     text: String
 ): AnnotatedString {
-    val tokens = Regex("""<.*?>|([^<]+)?|(&nbsp;)""").findAll(text)
+    val tokens = Regex("""<.*?>|(&nbsp;)+|([^<&]+)?""").findAll(text)
 
     // TODO: Implement <small> tags. (Apparently only used for base designation? https://github.com/Qalculate/libqalculate/blob/21f28b27bf99dc6d9f3325c4960a92ec9ee8934d/libqalculate/MathStructure-print.cc#L3604 )
 
@@ -32,7 +32,7 @@ fun mathExpressionFormatter(
                 "</sup>" -> pop()
                 "<sub>" -> pushStyle(SpanStyle(baselineShift = BaselineShift.Subscript, fontSize = 0.7.em))
                 "</sub>" -> pop()
-                "&nbsp;" -> append("\n")
+                "&nbsp;" -> pop()
                 else -> append(token.value)
             }
         }


### PR DESCRIPTION
Fixes #73.

I had to fiddle with the regex a bit, but it seems to be working.

I set the action for `&nbsp;` to pop it, otherwise it results in the main equation bar being unreadable (see image below).
 
![Screenshot](https://github.com/user-attachments/assets/dd5e16c4-95b1-4e50-a25d-4029035bb782)
