### PR TITLE
Select foreground colours based on background colours to ensure readability

### DIFF
--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/AboutCard.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/AboutCard.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.jherkenhoff.libqalculate.libqalculateConstants;
 import com.jherkenhoff.qalculate.BuildConfig
 import com.jherkenhoff.qalculate.R
 
@@ -64,7 +65,12 @@ fun AboutCard(
                     Column {
                         Text(text = "Qalculate!", style = MaterialTheme.typography.headlineSmall)
                         Text(
-                            text = "Version " + BuildConfig.VERSION_NAME
+                            text = "App version " + BuildConfig.VERSION_NAME
+                        )
+                        Text(
+                            text = "libqalculate version ${libqalculateConstants.QALCULATE_MAJOR_VERSION}" +
+                                    ".${libqalculateConstants.QALCULATE_MINOR_VERSION}" +
+                                    ".${libqalculateConstants.QALCULATE_MICRO_VERSION}"
                         )
                     }
                 }
@@ -96,7 +102,7 @@ fun LicenseText() {
                     TextLinkStyles(style = SpanStyle(textDecoration = TextDecoration.Underline))
                 )
             ) {
-                append("GNU  General Public License, version 2 or later")
+                append("GNU General Public License, version 2 or later")
             }
             append(" for details.")
         },

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/AboutCard.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/AboutCard.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.jherkenhoff.libqalculate.libqalculateConstants;
 import com.jherkenhoff.qalculate.BuildConfig
 import com.jherkenhoff.qalculate.R
 
@@ -65,12 +64,7 @@ fun AboutCard(
                     Column {
                         Text(text = "Qalculate!", style = MaterialTheme.typography.headlineSmall)
                         Text(
-                            text = "App version " + BuildConfig.VERSION_NAME
-                        )
-                        Text(
-                            text = "libqalculate version ${libqalculateConstants.QALCULATE_MAJOR_VERSION}" +
-                                    ".${libqalculateConstants.QALCULATE_MINOR_VERSION}" +
-                                    ".${libqalculateConstants.QALCULATE_MICRO_VERSION}"
+                            text = "Version " + BuildConfig.VERSION_NAME
                         )
                     }
                 }
@@ -102,7 +96,7 @@ fun LicenseText() {
                     TextLinkStyles(style = SpanStyle(textDecoration = TextDecoration.Underline))
                 )
             ) {
-                append("GNU General Public License, version 2 or later")
+                append("GNU  General Public License, version 2 or later")
             }
             append(" for details.")
         },

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/MainActivity.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/MainActivity.kt
@@ -3,7 +3,7 @@ package com.jherkenhoff.qalculate.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.core.view.WindowCompat
+import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.lifecycleScope
 import com.jherkenhoff.qalculate.data.AutocompleteRepository
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,7 +18,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        enableEdgeToEdge()
 
         setContent {
             QalculateApp()

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/MainActivity.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.jherkenhoff.qalculate.data.AutocompleteRepository
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,6 +19,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         enableEdgeToEdge()
 

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/AltKeyboard.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/AltKeyboard.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -21,7 +20,6 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/AltKeyboard.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/AltKeyboard.kt
@@ -13,12 +13,15 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -123,7 +126,7 @@ fun RowScope.AltKeyboardButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.secondary
+    color: Color
 ) {
     Button(
         onClick = onClick,
@@ -131,7 +134,7 @@ fun RowScope.AltKeyboardButton(
         colors = ButtonDefaults.buttonColors(containerColor = color),
         contentPadding = PaddingValues(4.dp)
     ) {
-        Text(text, style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurface)
+        Text(text, style = MaterialTheme.typography.headlineSmall, color = contentColorFor(color))
     }
 }
 
@@ -152,7 +155,7 @@ fun RowScope.AltKeyboardButton(
         Icon(
             icon,
             contentDescription = description,
-            tint = MaterialTheme.colorScheme.onSurface
+            tint = contentColorFor(color)
         )
     }
 }

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/CalculationDivider.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/CalculationDivider.kt
@@ -25,22 +25,18 @@ fun CalculationDivider(
             .height(16.dp)
     ) {
         HorizontalDivider(
-            modifier = Modifier
-                .weight(1f)
-                .align(Alignment.CenterVertically),
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+            modifier = Modifier.weight(1f).align(Alignment.CenterVertically),
+            color = MaterialTheme.colorScheme.outlineVariant
         )
         Text(
             text = text,
             style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(horizontal = 16.dp)
         )
         HorizontalDivider(
-            modifier = Modifier
-                .weight(1f)
-                .align(Alignment.CenterVertically),
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+            modifier = Modifier.weight(1f).align(Alignment.CenterVertically),
+            color = MaterialTheme.colorScheme.outlineVariant
         )
     }
 }

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/CalculatorScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -96,11 +97,10 @@ fun CalculatorScreenContent(
         topBar = {
             TopAppBar(
                 colors = topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface,
                 ),
-                title = {
-                },
+                title = {},
                 navigationIcon = {
                     IconButton(onClick = openDrawer) {
                         Icon(
@@ -111,9 +111,11 @@ fun CalculatorScreenContent(
 
                 },
                 actions = {
-                    SuggestionChip(onClick = { /*TODO*/ }, label = { Text("DEG") })
-                    SuggestionChip(onClick = { /*TODO*/ }, label = { Text("Exact") })
-                    SuggestionChip(onClick = { /*TODO*/ }, label = { Text("Exp.") })
+                    SuggestionChip(onClick = { /*TODO*/ }, enabled = false, label = { Text("DEG") })
+                    Spacer(Modifier.width(8.dp))
+                    SuggestionChip(onClick = { /*TODO*/ }, enabled = false, label = { Text("Exact") })
+                    Spacer(Modifier.width(8.dp))
+                    SuggestionChip(onClick = { /*TODO*/ }, enabled = false, label = { Text("Exp.") })
                 }
 
             )

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/InputSheet.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/InputSheet.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -18,12 +17,13 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Calculate
+import androidx.compose.material.icons.outlined.Calculate
 import androidx.compose.material.icons.outlined.Close
-import androidx.compose.material3.FilledIconToggleButton
+import androidx.compose.material3.FilledTonalIconToggleButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconToggleButtonColors
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -42,11 +42,13 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.jherkenhoff.qalculate.R
@@ -78,7 +80,7 @@ fun InputSheet(
     Surface(
         //shape = RoundedCornerShape(20.dp, 20.dp, 0.dp, 0.dp),
         shape = RoundedCornerShape(25.dp, 25.dp, 25.dp, 25.dp),
-        color = MaterialTheme.colorScheme.primaryContainer,
+        color = MaterialTheme.colorScheme.surfaceContainer,
         modifier = modifier.fillMaxWidth()
     ) {
         Column {
@@ -96,42 +98,38 @@ fun InputSheet(
                     .defaultMinSize(minHeight = 60.dp)
             )
 
-
             Text(
-                mathExpressionFormatter(parsed, color=true),
+                // If the parsed expression is empty, add placeholder text to fill the gap.
+                mathExpressionFormatter(parsed, color=true).ifEmpty { AnnotatedString(stringResource(R.string.parsed_expr_empty)) },
                 style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
                     .defaultMinSize(minHeight = 24.dp)
                     .wrapContentHeight(),
             )
+
             HorizontalDivider(
-                modifier = Modifier
-                    .height(1.dp)
-                    .fillMaxWidth(),
-                color = MaterialTheme.colorScheme.onPrimaryContainer
+                thickness = Dp.Hairline,
+                color = MaterialTheme.colorScheme.outlineVariant
             )
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.defaultMinSize(minHeight = 50.dp)
             ) {
-                FilledIconToggleButton(
+                FilledTonalIconToggleButton(
                     checked = isAltKeyboardOpen,
                     onCheckedChange = { onToggleAltKeyboard() },
-                    colors = IconToggleButtonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary,
-                        checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                        checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                        disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                        disabledContentColor = MaterialTheme.colorScheme.onSurface,
-                    ),
+                    colors = IconButtonDefaults.filledTonalIconToggleButtonColors(),
                     modifier = Modifier
                         .padding(5.dp)
                         .size(40.dp)
                 ) {
-                    Icon(Icons.Filled.Calculate, contentDescription = null)
+                    if (isAltKeyboardOpen) {
+                        Icon(Icons.Filled.Calculate, contentDescription = null)
+                    } else {
+                        Icon(Icons.Outlined.Calculate, contentDescription = null)
+                    }
                 }
 
                 Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/theme/Theme.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.jherkenhoff.qalculate.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,12 +9,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.ViewCompat
 import androidx.compose.ui.unit.dp
 
 private val DarkColorScheme = darkColorScheme(
@@ -61,15 +55,6 @@ fun QalculateTheme(
         }
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
-    }
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = Color.Transparent.toArgb()
-            window.navigationBarColor = Color.Transparent.toArgb()
-            ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme
-        }
     }
 
     MaterialTheme(

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/units/UnitsScreen.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/units/UnitsScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -34,6 +36,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -42,9 +45,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.jherkenhoff.qalculate.R
 
 data class UnitDefinition(
     val title: String,
@@ -123,17 +128,28 @@ fun UnitsScreenContent(
         ) {
 
             SearchBar(
-                query = searchString,
-                placeholder = { Text("search units") },
-                active = false,
-                trailingIcon = { Icon(Icons.Filled.Search, contentDescription = "Search icon") },
-                onActiveChange = {  },
-                onQueryChange = onSearchInputUpdate,
-                onSearch = {},
-                modifier = Modifier.align(Alignment.CenterHorizontally)
-            ) {
-
-            }
+                inputField = {
+                    SearchBarDefaults.InputField(
+                        query = searchString,
+                        onQueryChange = onSearchInputUpdate,
+                        onSearch = {},
+                        expanded = false,
+                        onExpandedChange = {},
+                        placeholder = { Text(stringResource(R.string.unit_search_placeholder)) },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Filled.Search,
+                                contentDescription = "Search icon"
+                            )
+                        },
+                    )
+                }, expanded = false, onExpandedChange = {},
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                windowInsets = WindowInsets(top = 0.dp)
+            ) { }
 
             Spacer(modifier = Modifier.size(8.dp))
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="navigation_about">About</string>
     <string name="navigation_settings">Settings</string>
     <string name="clear_input">Clear input</string>
+    <string name="unit_search_placeholder">Search units</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="top_sheet_arrow_down">Down arrow</string>
     <string name="top_sheet_menu">Menu button</string>
     <string name="textfield_hint">Enter expression</string>
+    <string name="parsed_expr_empty">(No input)</string>
     <string name="about_qalculate_text">Powerful and versatile multi-purpose calculator based on the almighty Qalculate! desktop calculator.</string>
     <string name="navigation_calculator">Calculator</string>
     <string name="navigation_functions">Functions</string>


### PR DESCRIPTION
Thanks for this app, I love qalc and having it on Android is great :)

The colours for text in the main calculator interface are now chosen by calling [`androidx.compose.material3.contentColorFor`](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#contentColorFor(androidx.compose.ui.graphics.Color)) with the background colour so that the contrast between the content and background is always good, even with dynamic colours. This fixes #75 insofar as maintaining readability, although it does not provide any settings for manually choosing the colours. However, as `contentColorFor` selects the appropriate foreground colour from the colour scheme and the app uses background colours from the same scheme, there should never be a situation where the user would need to change the colours manually in order to read the text.

Along the way I got a bit distracted and made a couple of other minor adjustments to bring things more into accordance with the Material guidelines on both the calculator and units screens.

On the left is the previous interface, and on the right is the one in this PR, both in the Pixel 5 emulator on Android 11:
<p>
<img src="https://github.com/user-attachments/assets/ee22e866-16ed-4048-95af-9f755aee434d" width="180">
<img src="https://github.com/user-attachments/assets/c36ffb0d-5e89-4a9b-b030-711782ecd980" width="180">
</p>

And on my Pixel 9 on Android 15:
<p>
<img src="https://github.com/user-attachments/assets/075192ed-07b8-4fac-97b5-415c0f32ac15" width="180">
<img src="https://github.com/user-attachments/assets/fd6426a1-d6c7-4be9-a31d-49a244585251" width="180">
</p>

In dark mode:
<p>
<img src="https://github.com/user-attachments/assets/8baa631e-f2ec-4313-94e7-a8fa390b7f80" width="180">
<img src="https://github.com/user-attachments/assets/249ba2d7-6969-4054-ad83-834072cfa901" width="180">
</p>

The units screen:
<p>
<img src="https://github.com/user-attachments/assets/3952ecd3-0df1-4708-8c7e-5f58715f7307" width="180">
<img src="https://github.com/user-attachments/assets/02b523ae-f912-4484-812f-6b034585370e" width="180">
</p>